### PR TITLE
Fix physical input devices with >2 channels not appearing as usable

### DIFF
--- a/pipewire/src/store.rs
+++ b/pipewire/src/store.rs
@@ -1042,11 +1042,11 @@ impl Store {
     // ----- UTILITY FUNCTIONS -----
     fn get_media_class(&self, in_count: usize, out_count: usize) -> Option<MediaClass> {
         // Return the Specific MediaClass based on Channel Count
-        if (1..=2).contains(&in_count) && (out_count == 0) {
+        if in_count >= 1 && out_count == 0 {
             return Some(MediaClass::Sink);
-        } else if (1..=2).contains(&out_count) && in_count == 0 {
+        } else if out_count >= 1 && in_count == 0 {
             return Some(MediaClass::Source);
-        } else if (1..=2).contains(&in_count) && in_count == out_count {
+        } else if in_count >= 1 && in_count == out_count {
             // This is a bit of an assumption really, but we have non-monitor ports on the
             // tail end, so a reasonable assumption.
             return Some(MediaClass::Duplex);


### PR DESCRIPTION
## Summary

- The `get_media_class` function in `pipewire/src/store.rs` restricted usable devices to 1-2 channels only (`(1..=2).contains(...)`)
- Multichannel input devices like the Focusrite Scarlett 2i2 4th Gen (which presents as a 4-channel Analog Surround 4.0 source in PipeWire) were marked `is_usable = false` and excluded from the physical device dropdown
- Changed the channel count check to `>= 1` so devices with any number of channels are recognized

## Test plan

- [x] Tested with Focusrite Scarlett 2i2 4th Gen (4-channel input) — device now appears in the source physical device dropdown
- [x] Assigned to a source and routed audio successfully through PipeWeaver
- [ ] Verify no regressions with standard 1-2 channel devices

Fixes #7